### PR TITLE
[#159174283] Create Bosh release for paas-metric-exporter

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "src/github.com/alphagov/paas-metric-exporter"]
+	path = src/github.com/alphagov/paas-metric-exporter
+	url = https://github.com/alphagov/paas-metric-exporter

--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -1,1 +1,5 @@
---- {}
+---
+golang/go1.8.linux-amd64.tar.gz:
+  object_id: 5246bccf-2d59-415c-a277-614054a11ed9
+  sha: a93fe8fc245e3554f956bc823f30ef4eb23c2068
+  size: 89803580

--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -1,5 +1,4 @@
----
-golang/go1.8.linux-amd64.tar.gz:
-  object_id: 5246bccf-2d59-415c-a277-614054a11ed9
-  sha: a93fe8fc245e3554f956bc823f30ef4eb23c2068
-  size: 89803580
+golang/go1.11.linux-amd64.tar.gz:
+  object_id: 3b1a8b08-c8a4-45d7-863c-1a8806818f67
+  size: 127163815
+  sha: 8ffb718cab4371df3495d8f6c0b15c7e6dc28fea

--- a/config/final.yml
+++ b/config/final.yml
@@ -1,1 +1,8 @@
-name: paas-metric-exporter-boshrelease
+---
+final_name: metric-exporter
+blobstore:
+  provider: s3
+  options:
+    bucket_name: gds-paas-build-releases-blobs
+    region: eu-west-1
+    endpoint: https://s3-eu-west-1.amazonaws.com

--- a/jobs/metric-exporter/monit
+++ b/jobs/metric-exporter/monit
@@ -1,0 +1,7 @@
+<% if spec.bootstrap %>
+check process metric-exporter
+  with pidfile /var/vcap/sys/run/metric-exporter/metric-exporter.pid
+  start program "/var/vcap/packages/bosh-helpers/monit_debugger metric-exporter-ctl '/var/vcap/jobs/metric-exporter/bin/metric-exporter-ctl start'"
+  stop program "/var/vcap/packages/bosh-helpers/monit_debugger metric-exporter-ctl '/var/vcap/jobs/metric-exporter/bin/metric-exporter-ctl stop'"
+  group vcap
+<% end %>

--- a/jobs/metric-exporter/monit
+++ b/jobs/metric-exporter/monit
@@ -1,7 +1,5 @@
-<% if spec.bootstrap %>
 check process metric-exporter
   with pidfile /var/vcap/sys/run/metric-exporter/metric-exporter.pid
   start program "/var/vcap/packages/bosh-helpers/monit_debugger metric-exporter-ctl '/var/vcap/jobs/metric-exporter/bin/metric-exporter-ctl start'"
   stop program "/var/vcap/packages/bosh-helpers/monit_debugger metric-exporter-ctl '/var/vcap/jobs/metric-exporter/bin/metric-exporter-ctl stop'"
   group vcap
-<% end %>

--- a/jobs/metric-exporter/spec
+++ b/jobs/metric-exporter/spec
@@ -6,9 +6,17 @@ packages:
   - metric-exporter
 
 templates:
+  bin/job_properties.sh.erb: bin/job_properties.sh
   bin/metric-exporter-ctl.erb: bin/metric-exporter-ctl
   config/loggregator.ca_cert.crt.erb: config/loggregator.ca_cert.crt
   config/loggregator.client_cert.crt.erb: config/loggregator.client_cert.crt
   config/loggregator.client_key.key.erb: config/loggregator.client_key.key
 
-properties: {}
+properties:
+  metric-exporter.cf_api_url:
+    description: "Cloud Foundry API URL"
+    example: "https://api.example.com"
+  metric-exporter.cf_username:
+    description: "Username for reading events from Loggregator"
+  metric-exporter.cf_password:
+    description: "Password for reading events from Loggregator"

--- a/jobs/metric-exporter/spec
+++ b/jobs/metric-exporter/spec
@@ -20,3 +20,9 @@ properties:
     description: "Username for reading events from Loggregator"
   metric-exporter.cf_password:
     description: "Password for reading events from Loggregator"
+  metric-exporter.loggregator.ca_cert:
+    description: "CA Cert for the loggregator ingress endpoint as a string"
+  metric-exporter.loggregator.client_cert:
+    description: "Client certificate for loggregator ingress traffic as a string"
+  metric-exporter.loggregator.client_key:
+    description: "Client certificate key for loggregator ingress traffic as a string"

--- a/jobs/metric-exporter/spec
+++ b/jobs/metric-exporter/spec
@@ -1,7 +1,10 @@
 ---
 name: metric-exporter
 
-templates: {}
+templates:
+  config/loggregator.ca_cert.crt.erb: config/loggregator.ca_cert.crt
+  config/loggregator.client_cert.crt.erb: config/loggregator.client_cert.crt
+  config/loggregator.client_key.key.erb: config/loggregator.client_key.key
 
 packages: []
 

--- a/jobs/metric-exporter/spec
+++ b/jobs/metric-exporter/spec
@@ -11,6 +11,9 @@ templates:
   config/loggregator.ca_cert.crt.erb: config/loggregator.ca_cert.crt
   config/loggregator.client_cert.crt.erb: config/loggregator.client_cert.crt
   config/loggregator.client_key.key.erb: config/loggregator.client_key.key
+  config/locket.ca_cert.crt.erb: config/locket.ca_cert.crt
+  config/locket.client_cert.crt.erb: config/locket.client_cert.crt
+  config/locket.client_key.key.erb: config/locket.client_key.key
 
 properties:
   metric-exporter.cf_api_url:
@@ -26,3 +29,15 @@ properties:
     description: "Client certificate for loggregator ingress traffic as a string"
   metric-exporter.loggregator.client_key:
     description: "Client certificate key for loggregator ingress traffic as a string"
+  metric-exporter.enable_locking:
+    description: "Whether to use locking via a Locket server"
+    default: true
+  metric-exporter.locket.api_location:
+    description: "The host and port for the Locket server"
+    example: "127.0.0.1:8891"
+  metric-exporter.locket.ca_cert:
+    description: "A PEM formatted certificate of a CA the Locket client will trust"
+  metric-exporter.locket.client_cert:
+    description: "A PEM formatted certificate used for client connections to the Locket server"
+  metric-exporter.locket.client_key:
+    description: "A PEM formatted key used for client connections to the Locket server"

--- a/jobs/metric-exporter/spec
+++ b/jobs/metric-exporter/spec
@@ -1,11 +1,14 @@
 ---
 name: metric-exporter
 
+packages:
+  - bosh-helpers
+  - metric-exporter
+
 templates:
+  bin/metric-exporter-ctl.erb: bin/metric-exporter-ctl
   config/loggregator.ca_cert.crt.erb: config/loggregator.ca_cert.crt
   config/loggregator.client_cert.crt.erb: config/loggregator.client_cert.crt
   config/loggregator.client_key.key.erb: config/loggregator.client_key.key
-
-packages: []
 
 properties: {}

--- a/jobs/metric-exporter/spec
+++ b/jobs/metric-exporter/spec
@@ -16,10 +16,10 @@ properties:
   metric-exporter.cf_api_url:
     description: "Cloud Foundry API URL"
     example: "https://api.example.com"
-  metric-exporter.cf_username:
-    description: "Username for reading events from Loggregator"
-  metric-exporter.cf_password:
-    description: "Password for reading events from Loggregator"
+  metric-exporter.client_id:
+    description: "ID of a UAA client to be used for reading from the firehose"
+  metric-exporter.client_secret:
+    description: "Secret for a UAA client to be used for reading from the firehose"
   metric-exporter.loggregator.ca_cert:
     description: "CA Cert for the loggregator ingress endpoint as a string"
   metric-exporter.loggregator.client_cert:

--- a/jobs/metric-exporter/spec
+++ b/jobs/metric-exporter/spec
@@ -41,3 +41,5 @@ properties:
     description: "A PEM formatted certificate used for client connections to the Locket server"
   metric-exporter.locket.client_key:
     description: "A PEM formatted key used for client connections to the Locket server"
+  metric-exporter.metric_whitelist:
+    description: "A comma-delimited list of metrics to include. See README at https://github.com/alphagov/paas-metric-exporter/tree/f8a69a4caff5b8e93b10e384af3314ed314692cc#metric-whitelist"

--- a/jobs/metric-exporter/templates/bin/job_properties.sh.erb
+++ b/jobs/metric-exporter/templates/bin/job_properties.sh.erb
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+#
+# Metric Exporter properties
+#
+
+# Directory to store configuration files
+export METRIC_EXPORTER_CONF_DIR=${JOB_DIR}/config
+
+# Directory to store log files
+export METRIC_EXPORTER_LOG_DIR=${LOG_DIR}
+
+# Directory to store process IDs
+export METRIC_EXPORTER_PID_DIR=${RUN_DIR}
+
+# Directory to store data files
+export METRIC_EXPORTER_STORE_DIR=${STORE_DIR}
+
+# Directory to store temp files
+export METRIC_EXPORTER_TMP_DIR=${TMP_DIR}

--- a/jobs/metric-exporter/templates/bin/job_properties.sh.erb
+++ b/jobs/metric-exporter/templates/bin/job_properties.sh.erb
@@ -19,11 +19,11 @@ export METRIC_EXPORTER_STORE_DIR=${STORE_DIR}
 # Directory to store temp files
 export METRIC_EXPORTER_TMP_DIR=${TMP_DIR}
 
-# CF API URL
 export API_ENDPOINT=<%= p('metric-exporter.cf_api_url') %>
-
-# UAA client ID
 export CLIENT_ID=<%= p('metric-exporter.client_id') %>
-
-# UAA client secret
 export CLIENT_SECRET=<%= p('metric-exporter.client_secret') %>
+export ENABLE_LOCKING=<%= p('metric-exporter.enable_locking') %>
+export LOCKET_API_LOCATION=<%= p('metric-exporter.locket.api_location') %>
+
+export ENABLE_STATSD=false
+export ENABLE_LOGGREGATOR=true

--- a/jobs/metric-exporter/templates/bin/job_properties.sh.erb
+++ b/jobs/metric-exporter/templates/bin/job_properties.sh.erb
@@ -18,3 +18,12 @@ export METRIC_EXPORTER_STORE_DIR=${STORE_DIR}
 
 # Directory to store temp files
 export METRIC_EXPORTER_TMP_DIR=${TMP_DIR}
+
+# CF API URL
+export API_ENDPOINT=<%= p('metric-exporter.cf_api_url') %>
+
+# CF username
+export USERNAME=<%= p('metric-exporter.cf_username') %>
+
+# CF password
+export PASSWORD=<%= p('metric-exporter.cf_password') %>

--- a/jobs/metric-exporter/templates/bin/job_properties.sh.erb
+++ b/jobs/metric-exporter/templates/bin/job_properties.sh.erb
@@ -25,5 +25,9 @@ export CLIENT_SECRET=<%= p('metric-exporter.client_secret') %>
 export ENABLE_LOCKING=<%= p('metric-exporter.enable_locking') %>
 export LOCKET_API_LOCATION=<%= p('metric-exporter.locket.api_location') %>
 
+<% if_p('metric-exporter.metric_whitelist') do |metric_whitelist| %>
+export METRIC_WHITELIST="<%= metric_whitelist %>"
+<% end %>
+
 export ENABLE_STATSD=false
 export ENABLE_LOGGREGATOR=true

--- a/jobs/metric-exporter/templates/bin/job_properties.sh.erb
+++ b/jobs/metric-exporter/templates/bin/job_properties.sh.erb
@@ -22,8 +22,8 @@ export METRIC_EXPORTER_TMP_DIR=${TMP_DIR}
 # CF API URL
 export API_ENDPOINT=<%= p('metric-exporter.cf_api_url') %>
 
-# CF username
-export USERNAME=<%= p('metric-exporter.cf_username') %>
+# UAA client ID
+export CLIENT_ID=<%= p('metric-exporter.client_id') %>
 
-# CF password
-export PASSWORD=<%= p('metric-exporter.cf_password') %>
+# UAA client secret
+export CLIENT_SECRET=<%= p('metric-exporter.client_secret') %>

--- a/jobs/metric-exporter/templates/bin/metric-exporter-ctl.erb
+++ b/jobs/metric-exporter/templates/bin/metric-exporter-ctl.erb
@@ -12,9 +12,6 @@ case $1 in
     pid_guard ${METRIC_EXPORTER_PID_FILE} ${JOB_NAME}
     echo $$ > ${METRIC_EXPORTER_PID_FILE}
 
-    export ENABLE_STATSD=false
-    export ENABLE_LOGGREGATOR=true
-
     exec /var/vcap/packages/metric-exporter/bin/paas-metric-exporter \
       > >(tee -a ${METRIC_EXPORTER_LOG_DIR}/${OUTPUT_LABEL}.stdout.log | logger -t vcap.${OUTPUT_LABEL}.stdout) \
       2> >(tee -a ${METRIC_EXPORTER_LOG_DIR}/${OUTPUT_LABEL}.stderr.log | logger -t vcap.${OUTPUT_LABEL}.stderr)

--- a/jobs/metric-exporter/templates/bin/metric-exporter-ctl.erb
+++ b/jobs/metric-exporter/templates/bin/metric-exporter-ctl.erb
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+set -e # exit immediately if a simple command exits with a non-zero status
+
+# Setup common env vars and folders
+source /var/vcap/packages/bosh-helpers/ctl_setup.sh 'metric-exporter'
+export METRIC_EXPORTER_PID_FILE=${METRIC_EXPORTER_PID_DIR}/metric-exporter.pid
+
+case $1 in
+
+  start)
+    pid_guard ${METRIC_EXPORTER_PID_FILE} ${JOB_NAME}
+    echo $$ > ${METRIC_EXPORTER_PID_FILE}
+
+    # TODO: add the metric-exporter package and setup config.json
+    exec /var/vcap/packages/metric-exporter/bin/paas-metric-exporter \
+      -config=${METRIC_EXPORTER_CONF_DIR}/config.json \
+      > >(tee -a ${METRIC_EXPORTER_LOG_DIR}/${OUTPUT_LABEL}.stdout.log | logger -t vcap.${OUTPUT_LABEL}.stdout) \
+      2> >(tee -a ${METRIC_EXPORTER_LOG_DIR}/${OUTPUT_LABEL}.stderr.log | logger -t vcap.${OUTPUT_LABEL}.stderr)
+    ;;
+
+  stop)
+    kill_and_wait ${METRIC_EXPORTER_PID_FILE}
+    ;;
+
+  *)
+    echo "Usage: $0 {start|stop}"
+    exit 1
+    ;;
+
+esac
+exit 0

--- a/jobs/metric-exporter/templates/bin/metric-exporter-ctl.erb
+++ b/jobs/metric-exporter/templates/bin/metric-exporter-ctl.erb
@@ -12,9 +12,10 @@ case $1 in
     pid_guard ${METRIC_EXPORTER_PID_FILE} ${JOB_NAME}
     echo $$ > ${METRIC_EXPORTER_PID_FILE}
 
-    # TODO: add the metric-exporter package and setup config.json
+    export ENABLE_STATSD=false
+    export ENABLE_LOGGREGATOR=true
+
     exec /var/vcap/packages/metric-exporter/bin/paas-metric-exporter \
-      -config=${METRIC_EXPORTER_CONF_DIR}/config.json \
       > >(tee -a ${METRIC_EXPORTER_LOG_DIR}/${OUTPUT_LABEL}.stdout.log | logger -t vcap.${OUTPUT_LABEL}.stdout) \
       2> >(tee -a ${METRIC_EXPORTER_LOG_DIR}/${OUTPUT_LABEL}.stderr.log | logger -t vcap.${OUTPUT_LABEL}.stderr)
     ;;

--- a/jobs/metric-exporter/templates/config/locket.ca_cert.crt.erb
+++ b/jobs/metric-exporter/templates/config/locket.ca_cert.crt.erb
@@ -1,0 +1,1 @@
+<%= p('metric-exporter.locket.ca_cert') %>

--- a/jobs/metric-exporter/templates/config/locket.client_cert.crt.erb
+++ b/jobs/metric-exporter/templates/config/locket.client_cert.crt.erb
@@ -1,0 +1,1 @@
+<%= p('metric-exporter.locket.client_cert') %>

--- a/jobs/metric-exporter/templates/config/locket.client_key.key.erb
+++ b/jobs/metric-exporter/templates/config/locket.client_key.key.erb
@@ -1,0 +1,1 @@
+<%= p('metric-exporter.locket.client_key') %>

--- a/jobs/metric-exporter/templates/config/loggregator.ca_cert.crt.erb
+++ b/jobs/metric-exporter/templates/config/loggregator.ca_cert.crt.erb
@@ -1,0 +1,1 @@
+<%= p('metric-exporter.loggregator.ca_cert') %>

--- a/jobs/metric-exporter/templates/config/loggregator.client_cert.crt.erb
+++ b/jobs/metric-exporter/templates/config/loggregator.client_cert.crt.erb
@@ -1,0 +1,2 @@
+<%= p('metric-exporter.loggregator.client_cert') %>
+

--- a/jobs/metric-exporter/templates/config/loggregator.client_key.key.erb
+++ b/jobs/metric-exporter/templates/config/loggregator.client_key.key.erb
@@ -1,0 +1,2 @@
+<%= p('metric-exporter.loggregator.client_key') %>
+

--- a/packages/bosh-helpers/packaging
+++ b/packages/bosh-helpers/packaging
@@ -1,0 +1,6 @@
+set -e # exit immediately if a simple command exits with a non-zero status
+set -u # report the usage of uninitialized variables
+
+# Copy Bosh Helpers package
+echo "Copying Bosh Helpers..."
+cp -a ${BOSH_COMPILE_TARGET}/bosh-helpers/* ${BOSH_INSTALL_TARGET}/

--- a/packages/bosh-helpers/spec
+++ b/packages/bosh-helpers/spec
@@ -1,0 +1,5 @@
+---
+name: bosh-helpers
+dependencies: []
+files:
+  - bosh-helpers/*

--- a/packages/golang/packaging
+++ b/packages/golang/packaging
@@ -1,0 +1,18 @@
+set -e # exit immediately if a simple command exits with a non-zero status
+set -u # report the usage of uninitialized variables
+
+# We grab the latest versions that are in the directory
+GOLANG_VERSION=`ls -r golang/go* | sed 's/golang\/go\(.*\)\.linux-amd64.tar.gz/\1/' | head -1`
+
+# Extract Go Programming Language package
+echo "Extracting Go Programming Language ${GOLANG_VERSION}..."
+tar xzvf ${BOSH_COMPILE_TARGET}/golang/go${GOLANG_VERSION}.linux-amd64.tar.gz
+if [[ $? != 0 ]] ; then
+  echo "Failed extracting Go Programming Language ${GOLANG_VERSION}"
+  exit 1
+fi
+
+# Copy Go Programming Language package
+echo "Copying Go Programming Language..."
+mkdir -p ${BOSH_INSTALL_TARGET}/bin
+cp -a ${BOSH_COMPILE_TARGET}/go/* ${BOSH_INSTALL_TARGET}

--- a/packages/golang/spec
+++ b/packages/golang/spec
@@ -1,0 +1,5 @@
+---
+name: golang
+dependencies: []
+files:
+  - golang/go1.8.linux-amd64.tar.gz

--- a/packages/golang/spec
+++ b/packages/golang/spec
@@ -2,4 +2,4 @@
 name: golang
 dependencies: []
 files:
-  - golang/go1.8.linux-amd64.tar.gz
+  - golang/go1.11.linux-amd64.tar.gz

--- a/packages/metric-exporter/packaging
+++ b/packages/metric-exporter/packaging
@@ -1,0 +1,17 @@
+set -e # exit immediately if a simple command exits with a non-zero status
+set -u # report the usage of uninitialized variables
+
+# Set Golang dependency
+export GOROOT=$(readlink -nf /var/vcap/packages/golang)
+export PATH=${GOROOT}/bin:${PATH}
+
+# Build Metric Exporter package
+echo "Building Metric Exporter..."
+PACKAGE_NAME=github.com/alphagov/paas-metric-exporter
+mkdir -p ${BOSH_INSTALL_TARGET}/src/${PACKAGE_NAME}
+cp -a ${BOSH_COMPILE_TARGET}/${PACKAGE_NAME}/* ${BOSH_INSTALL_TARGET}/src/${PACKAGE_NAME}
+export GOPATH=${BOSH_INSTALL_TARGET}:${BOSH_INSTALL_TARGET}/src/${PACKAGE_NAME}/Godeps/_workspace
+go install ${PACKAGE_NAME}
+
+# Clean up pkg artifacts
+rm -rf ${BOSH_INSTALL_TARGET}/pkg

--- a/packages/metric-exporter/spec
+++ b/packages/metric-exporter/spec
@@ -1,0 +1,6 @@
+---
+name: metric-exporter
+dependencies:
+  - golang
+files:
+  - github.com/alphagov/paas-metric-exporter/**/*

--- a/src/bosh-helpers/ctl_setup.sh
+++ b/src/bosh-helpers/ctl_setup.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+
+# Setup env vars and folders for the ctl script
+# This helps keep the ctl script as readable as possible
+
+# Usage options:
+# source /var/vcap/jobs/foobar/helpers/ctl_setup.sh JOB_NAME OUTPUT_LABEL
+# source /var/vcap/jobs/foobar/helpers/ctl_setup.sh foobar
+# source /var/vcap/jobs/foobar/helpers/ctl_setup.sh foobar foobar
+# source /var/vcap/jobs/foobar/helpers/ctl_setup.sh foobar nginx
+
+set -e # exit immediately if a simple command exits with a non-zero status
+
+export JOB_NAME=$1
+export OUTPUT_LABEL=${2:-$JOB_NAME}
+
+# Setup job home folder
+export HOME=/var/vcap
+export JOB_DIR=$HOME/jobs/$JOB_NAME
+
+# Setup log, run, store and tmp folders
+export LOG_DIR=$HOME/sys/log/$JOB_NAME
+export RUN_DIR=$HOME/sys/run/$JOB_NAME
+export STORE_DIR=$HOME/store/$JOB_NAME
+export TMP_DIR=$HOME/sys/tmp/$JOB_NAME
+export TMPDIR=$TMP_DIR
+for dir in $LOG_DIR $RUN_DIR $STORE_DIR $TMP_DIR
+do
+  mkdir -p ${dir}
+  chown vcap:vcap ${dir}
+  chmod 775 ${dir}
+done
+
+# Load job properties
+if [ -f $JOB_DIR/bin/job_properties.sh ]; then
+  source $JOB_DIR/bin/job_properties.sh
+fi
+
+# Load some control helpers
+source $HOME/packages/bosh-helpers/ctl_utils.sh
+
+# Redirect output
+redirect_output ${OUTPUT_LABEL}

--- a/src/bosh-helpers/ctl_utils.sh
+++ b/src/bosh-helpers/ctl_utils.sh
@@ -1,0 +1,219 @@
+#!/usr/bin/env bash
+
+##
+# Helper functions used by control scripts
+#
+
+##
+# Creates a user grouo
+#
+# Example usage:
+# create_group group_name
+# create_group vcap
+create_group() {
+  group_name=$1
+  getent group $group_name &>/dev/null || groupadd $group_name
+}
+
+##
+# Creates a user
+#
+# Example usage:
+# create_user user_name group_name
+# create_user vcap vcap
+create_user() {
+  user_name=$1
+  group_name=$2
+  id $user_name &>/dev/null || useradd -s /sbin/nologin -r -M $user_name -G $group_name
+}
+
+##
+# Links a job file into a package
+#
+# Example usage:
+# link_job_file_to_package config/redis.yml [config/redis.yml]
+link_job_file_to_package() {
+  source_job_file=$1
+  target_package_file=${2:-$source_job_file}
+  full_package_file=$WEBAPP_DIR/${target_package_file}
+
+  link_job_file ${source_job_file} ${full_package_file}
+}
+
+##
+# Links a job file somewhere
+#
+# Example usage:
+# link_job_file config/bashrc /home/vcap/.bashrc
+link_job_file() {
+  source_job_file=$1
+  target_file=$2
+  full_job_file=$JOB_DIR/${source_job_file}
+
+  echo link_job_file ${full_job_file} ${target_file}
+  if [[ ! -f ${full_job_file} ]]
+  then
+    echo "File ${full_job_file} does not exist"
+  else
+    # Create/recreate the symlink to current job file
+    # If another process is using the file, it won't be
+    # deleted, so don't attempt to create the symlink
+    mkdir -p $(dirname ${target_file})
+    ln -nfs ${full_job_file} ${target_file}
+  fi
+}
+
+##
+# Redirects output
+#
+# Example usage:
+# redirect_output jobname
+redirect_output() {
+  SCRIPT=$1
+  mkdir -p $HOME/sys/log/monit
+  exec 1>> $HOME/sys/log/monit/$SCRIPT.log
+  exec 2>> $HOME/sys/log/monit/$SCRIPT.err.log
+}
+
+##
+# Guard for pidfiles
+#
+# Example usage:
+# pid_guard /var/vcap/sys/run/pidfile.pid jobname
+pid_guard() {
+  pidfile=$1
+  name=$2
+
+  if [ -f "$pidfile" ]; then
+    pid=$(head -1 "$pidfile")
+
+    if [ -n "$pid" ] && [ -e /proc/$pid ]; then
+      echo "$name is already running, please stop it first"
+      exit 1
+    fi
+
+    echo "Removing stale pidfile..."
+    rm $pidfile
+  fi
+}
+
+wait_pid() {
+  pid=$1
+  try_kill=$2
+  timeout=${3:-0}
+  force=${4:-0}
+  countdown=$(( $timeout * 10 ))
+
+  echo wait_pid $pid $try_kill $timeout $force $countdown
+  if [ -e /proc/$pid ]; then
+    if [ "$try_kill" = "1" ]; then
+      echo "Killing $pidfile: $pid "
+      kill $pid
+    fi
+    while [ -e /proc/$pid ]; do
+      sleep 0.1
+      [ "$countdown" != '0' -a $(( $countdown % 10 )) = '0' ] && echo -n .
+      if [ $timeout -gt 0 ]; then
+        if [ $countdown -eq 0 ]; then
+          if [ "$force" = "1" ]; then
+            echo -ne "\nKill timed out, using kill -9 on $pid... "
+            kill -9 $pid
+            sleep 0.5
+          fi
+          break
+        else
+          countdown=$(( $countdown - 1 ))
+        fi
+      fi
+    done
+    if [ -e /proc/$pid ]; then
+      echo "Timed Out"
+    else
+      echo "Stopped"
+    fi
+  else
+    echo "Process $pid is not running"
+    echo "Attempting to kill pid anyway..."
+    kill $pid
+  fi
+}
+
+wait_pidfile() {
+  pidfile=$1
+  try_kill=$2
+  timeout=${3:-0}
+  force=${4:-0}
+  countdown=$(( $timeout * 10 ))
+
+  if [ -f "$pidfile" ]; then
+    pid=$(head -1 "$pidfile")
+    if [ -z "$pid" ]; then
+      echo "Unable to get pid from $pidfile"
+      exit 1
+    fi
+
+    wait_pid $pid $try_kill $timeout $force
+
+    rm -f $pidfile
+  else
+    echo "Pidfile $pidfile doesn't exist"
+  fi
+}
+
+kill_and_wait() {
+  pidfile=$1
+  # Monit default timeout for start/stop is 30s
+  # Append 'with timeout {n} seconds' to monit start/stop program configs
+  timeout=${2:-25}
+  force=${3:-1}
+  if [[ -f ${pidfile} ]]
+  then
+    wait_pidfile $pidfile 1 $timeout $force
+  else
+    # TODO assume $1 is something to grep from 'ps ax'
+    pid="$(ps auwwx | grep "$1" | awk '{print $2}')"
+    wait_pid $pid 1 $timeout $force
+  fi
+}
+
+check_nfs_mount() {
+  opts=$1
+  exports=$2
+  mount_point=$3
+
+  if grep -qs $mount_point /proc/mounts; then
+    echo "Found NFS mount $mount_point"
+  else
+    echo "Mounting NFS..."
+    mount $opts $exports $mount_point
+    if [ $? != 0 ]; then
+      echo "Cannot mount NFS from $exports to $mount_point, exiting..."
+      exit 1
+    fi
+  fi
+}
+
+public_hostname() {
+  public_hostname=""
+
+  # AWS EC2
+  if ec2_hostname="$(curl -sSf --connect-timeout 1 http://169.254.169.254/latest/meta-data/public-hostname 2> /dev/null)"; then
+    public_hostname=$ec2_hostname
+  fi
+
+  echo $public_hostname
+}
+
+public_ip_address() {
+  public_ip_address=""
+
+  # AWS
+  if ec2_public_ip_address="$(curl -sSf --connect-timeout 1 http://169.254.169.254/latest/meta-data/public-ipv4 2> /dev/null)"; then
+    public_ip_address=$ec2_public_ip_address
+  # Google Compute Engine
+  elif gce_public_ip_address="$(curl -sSf --connect-timeout 1 -H "Metadata-Flavor: Google" http://169.254.169.254/computeMetadata/v1/instance/network-interfaces/0/access-configs/0/external-ip 2> /dev/null)"; then
+    public_ip_address=$gce_public_ip_address
+  fi
+
+  echo $public_ip_address
+}

--- a/src/bosh-helpers/monit_debugger
+++ b/src/bosh-helpers/monit_debugger
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+# USAGE monit_debugger <label> <command-to-run>
+export MONIT_LOG_DIR=/var/vcap/sys/log/monit
+mkdir -p $MONIT_LOG_DIR
+{
+  echo "MONIT-DEBUG date"
+  date
+  echo "MONIT-DEBUG env"
+  env
+  echo "MONIT-DEBUG $@"
+  $2 $3 $4 $5 $6 $7
+  R=$?
+  echo "MONIT-DEBUG exit code $R"
+} >$MONIT_LOG_DIR/monit_debugger.$1.log 2>&1


### PR DESCRIPTION
## What

The paas-metric-exporter has been extended to be able to send metrics to Loggregator. This means it has to write to a local Metron Agent, and therefore is being deployed as a Bosh release.

## How to review

Review in conjunction with https://github.com/alphagov/paas-cf/pull/1559. You can deploy it using the branch there.

## Before merging ⚠️ 

Review and merge https://github.com/alphagov/paas-metric-exporter/pull/32 first, then update the temporary commit on this branch to point the submodule at the new tip of master.

## Who

Anyone but me.